### PR TITLE
RF-1.0.1.4.1 Uninstall functionality updated

### DIFF
--- a/src/main/bash/commands/kobman-uninstall.sh
+++ b/src/main/bash/commands/kobman-uninstall.sh
@@ -6,61 +6,42 @@ local environment version
 environment=$1
 version=$2
 
-if [[ $environment == "all" ]]; then
-  if [[ $INTERACTIVE_MODE == "true" ]]; then
-    __kobman_echo_white "This operation would remove all the environments and its files"
-    __kobman_interactive_uninstall || return 1
-    __kobman_echo_white "Removing files..."
-    rm -rf $KOBMAN_DIR/envs/kob_env_*
-    rm -rf ~/Dev_*
-    __kobman_echo_white "Files removed successfully."
-    return 0
-  else
-    
-    __kobman_echo_white "Removing files..."
-    rm -rf $KOBMAN_DIR/envs/kob_env_*
-    rm -rf ~/Dev_*
-    __kobman_echo_white "Files removed successfully."
-    return 0
-  fi
-fi
-
 __kobman_check_parameter_present "$environment" "$version" || return 1
 
-if [[ $version == $(cat $KOBMAN_DIR/envs/kob_env_$environment/current) ]]; then  
-  if [[ $INTERACTIVE_MODE == "true" ]]; then
-    __kobman_echo_white "This operation would remove the current version $version for $environment"
-    __kobman_interactive_uninstall || return 1
-    __kobman_echo_no_colour "Uninstalling version $version of $environment"
-    __kobman_echo_no_colour "This would leave the environment without a current"
-    rm $KOBMAN_DIR/envs/kob_env_$environment/current 
-    rm -rf $KOBMAN_DIR/envs/kob_env_$environment/$version 
-    __kobman_uninstall_$environment
-    __kobman_echo_green "Version $version for $environment has been uninstalled successfully"
-  else
-    
-    __kobman_echo_no_colour "Uninstalling version $version of $environment"
-    __kobman_echo_no_colour "This would leave the environment without a current"
-    rm $KOBMAN_DIR/envs/kob_env_$environment/current 
-    rm -rf $KOBMAN_DIR/envs/kob_env_$environment/$version 
-    __kobman_uninstall_$environment
-    __kobman_echo_green "Version $version for $environment has been uninstalled successfully"
+if [[ $environment == "all" && -z $version ]]; then
+  
+  __kobman_echo_white "This operation would remove all the environments and its files"
+  __kobman_interactive_uninstall || return 1
+  __kobman_echo_white "Removing files..."
+  rm -rf $KOBMAN_DIR/envs/kob_env_*
+  rm -rf ~/Dev_*
+  __kobman_echo_green "Files removed successfully."
 
-  fi
-else
-  if [[ $INTERACTIVE_MODE == "true" ]]; then
+elif [[ -f $KOBMAN_DIR/envs/kob_env_$environment/current && $version == $(cat $KOBMAN_DIR/envs/kob_env_$environment/current) ]]; then  
+
+  __kobman_echo_white "This operation would remove the current version $version for $environment"
+  __kobman_echo_cyan "This would leave the environment without a current"
+  __kobman_interactive_uninstall || return 1
+  __kobman_echo_no_colour "Uninstalling version $version of $environment"
+  rm $KOBMAN_DIR/envs/kob_env_$environment/current 
+  rm -rf $KOBMAN_DIR/envs/kob_env_$environment/$version 
+  __kobman_uninstall_$environment
+  __kobman_echo_green "Version $version for $environment has been uninstalled successfully"
+  
+elif [[ -f $KOBMAN_DIR/envs/kob_env_$environment/current && $version != $(cat $KOBMAN_DIR/envs/kob_env_$environment/current) ]]; then  
+
   __kobman_echo_white "$version for $environment is not the current version"
   __kobman_echo_white "The operation will still remove the files for the version."
   __kobman_interactive_uninstall || return 1
-     __kobman_echo_no_colour "Removing files..."
-    rm -rf $KOBMAN_DIR/envs/kob_env_$environment/$version
-    __kobman_echo_green "Files removed successfully."
-  else
-    __kobman_echo_no_colour "Removing files..."
-    rm -rf $KOBMAN_DIR/envs/kob_env_$environment/$version
-    __kobman_echo_green "Files removed successfully."
-  fi
+  __kobman_echo_no_colour "Removing files..."
+  rm -rf $KOBMAN_DIR/envs/kob_env_$environment/$version
+  __kobman_echo_green "Files removed successfully."
+
+else
+  __kobman_echo_violet "Something went wrong"
+  __kobman_echo_violet "Please re-install $environment and try again"
 fi
+
 } 
 
 

--- a/src/main/bash/kobman-env-helpers.sh
+++ b/src/main/bash/kobman-env-helpers.sh
@@ -7,28 +7,36 @@ function __kobman_check_parameter_present
   local environment=$1
   local version=$2
 
-  kob status > status.txt
+  if [[ $environment == "all" ]]; then
+    return 0
+  fi
 
-  cat status.txt | grep -w $environment | grep -qw $version
-  if [[ "$?" != "0" ]]; then
-    __kobman_echo_red "Parameter not found in the local system."
+  if [[ ! -d $KOBMAN_DIR/envs/kob_env_$environment ]]; then
+    __kobman_echo_red "$environment is not installed in your local system"
     return 1
   fi
-  rm status.txt
+  
+  if [[ ! -d $KOBMAN_DIR/envs/kob_env_$environment/$version ]]; then
+    __kobman_echo_red "Version $version for $environment is not installed in your system."
+    return 1
+  fi
+  
 }
 
 
 function __kobman_interactive_uninstall
 {
- 
-  
-  read -p "Would you like to proceed?(y/n):" c
+  if [[ $INTERACTIVE_MODE = "true" ]]; then
+    read -p "Would you like to proceed?(y/n):" c
     if [[ $c == "n" ]]; then
       __kobman_echo_no_colour "Exiting!!!"
       return 1
     else
       return 0
     fi
+  else
+    return 0
+  fi
 }
 
 

--- a/src/main/bash/kobman-init.sh
+++ b/src/main/bash/kobman-init.sh
@@ -15,7 +15,9 @@ if [ -z "$KOBMAN_DIR" ]; then
 	export KOBMAN_DIR="$HOME/.kobman"
 fi
 
-
+if [[ -z "$INTERACTIVE_MODE" ]]; then
+	export INTERACTIVE_MODE="true"
+fi
 # infer platform
 KOBMAN_PLATFORM="$(uname)"
 if [[ "$KOBMAN_PLATFORM" == 'Linux' ]]; then

--- a/src/main/bash/kobman-main.sh
+++ b/src/main/bash/kobman-main.sh
@@ -113,11 +113,13 @@ function __kobman_identify_parameter
 		__kobman_check_if_version_exists "${qualifier2}" "${qualifier4}" || return 1
 	fi
 
-	if [[ -z "${qualifier3}" && "$converted_cmd_name" == "uninstall" ]]; then
+	if [[ -z "${qualifier3}" && "$converted_cmd_name" == "uninstall" && -d $KOBMAN_DIR/envs/kob_env_$qualifier2 ]]; then
 		qualifier4=($(cat $KOBMAN_DIR/envs/kob_env_$qualifier2/current))
 		__kobman_validate_version_format "$qualifier4" || return 1
 		__kobman_check_if_version_exists "${qualifier2}" "$qualifier4" || return 1
-	elif [ -z "${qualifier3}" ]; then
+	fi
+	
+	if [[ -z "${qualifier3}" && $converted_cmd_name = "install" ]]; then
 		__kobman_validate_version_format "$KOBMAN_VERSION" || return 1
 		__kobman_check_if_version_exists "${qualifier2}" "$KOBMAN_VERSION" || return 1
 	fi


### PR DESCRIPTION
- Global variable added under init file.
- Optimised the code for uninstall
- Fixed issue 
- Check for interactive mode moved to env-helpers file.
@EtricKombat 
Steps for running the uninstall.
1. Ensure an env with a current version is installed in your system.
2. Interactive mode will be "true"  by default
3. To uninstall the current version for an env, run
   - $ kob uninstall -env [env_name]
4. To uninstall in non-interactive mode, run
  - export INTERACTIVE_MODE="false"
5. To remove a non-current version for an env, run
  - $ kob uninstall -env [env_name] -V [version] 
6. To remove all the locally available versions for an env, run
 - $ kob uninstall -env all